### PR TITLE
添加最小依赖cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,41 @@
+#------------------------------------------------------------------------------
+# Top-level CMake file for FISCO-BCOS.
+# ------------------------------------------------------------------------------
+# This file is part of FISCO-BCOS.
+#
+# FISCO-BCOS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FISCO-BCOS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2018 fisco-dev contributors.
+#------------------------------------------------------------------------------
+
+cmake_minimum_required(VERSION 3.4)
+set(FISCO_BCOS_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}/cmake" CACHE PATH "The path to the cmake directory")
+list(APPEND CMAKE_MODULE_PATH ${FISCO_BCOS_CMAKE_DIR})
+
+project(FISCO-BCOS VERSION "2.0")
+
+set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY On)
+
+# basic setting
+include(EthOptions)
+include(EthCompilerSettings)
+
+# install dependencies
+include(ProjectCryptopp)
+include(ProjectSecp256k1)
+include(ProjectJsonCpp)
+include(ProjectJsonRpcCpp)
+include(ProjectBoost)
+
+configure_project()

--- a/cmake/EthBuildInfo.cmake
+++ b/cmake/EthBuildInfo.cmake
@@ -1,0 +1,70 @@
+#------------------------------------------------------------------------------
+# define and implement create_build_info function
+# this function is used to generate BuildInfo.h (called by the source code)
+# ------------------------------------------------------------------------------
+# This file is part of FISCO-BCOS.
+#
+# FISCO-BCOS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FISCO-BCOS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2018 fisco-dev contributors.
+#------------------------------------------------------------------------------
+function(create_build_info)
+    # Set build platform; to be written to BuildInfo.h
+    set(ETH_BUILD_OS "${CMAKE_SYSTEM_NAME}")
+
+    if (CMAKE_COMPILER_IS_MINGW)
+        set(ETH_BUILD_COMPILER "mingw")
+    elseif (CMAKE_COMPILER_IS_MSYS)
+        set(ETH_BUILD_COMPILER "msys")
+    elseif (CMAKE_COMPILER_IS_GNUCXX)
+        set(ETH_BUILD_COMPILER "g++")
+    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        set(ETH_BUILD_COMPILER "clang")
+    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+        set(ETH_BUILD_COMPILER "appleclang")
+    else ()
+        set(ETH_BUILD_COMPILER "unknown")
+    endif ()
+
+    if (EVMJIT)
+        set(ETH_BUILD_JIT_MODE "JIT")
+    else ()
+        set(ETH_BUILD_JIT_MODE "Interpreter")
+    endif ()
+
+    set(ETH_BUILD_PLATFORM "${ETH_BUILD_OS}/${ETH_BUILD_COMPILER}/${ETH_BUILD_JIT_MODE}")
+
+    if (CMAKE_BUILD_TYPE)
+        set(_cmake_build_type ${CMAKE_BUILD_TYPE})
+    else()
+        set(_cmake_build_type "${CMAKE_CFG_INTDIR}")
+    endif()
+
+    # Generate header file containing useful build information
+    add_custom_target(BuildInfo.h ALL
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        COMMAND ${CMAKE_COMMAND} -DETH_SOURCE_DIR="${PROJECT_SOURCE_DIR}" -DETH_BUILDINFO_IN="${ETH_CMAKE_DIR}/templates/BuildInfo.h.in" -DETH_DST_DIR="${PROJECT_BINARY_DIR}/include" -DETH_CMAKE_DIR="${ETH_CMAKE_DIR}"
+        -DETH_BUILD_TYPE="${_cmake_build_type}"
+        -DETH_BUILD_OS="${ETH_BUILD_OS}"
+        -DETH_BUILD_COMPILER="${ETH_BUILD_COMPILER}"
+        -DETH_BUILD_JIT_MODE="${ETH_BUILD_JIT_MODE}"
+        -DETH_BUILD_PLATFORM="${ETH_BUILD_PLATFORM}"
+        -DETH_BUILD_NUMBER="${BUILD_NUMBER}"
+        -DETH_VERSION_SUFFIX="${VERSION_SUFFIX}"
+        -DPROJECT_VERSION="${PROJECT_VERSION}"
+        -DETH_FATDB="${FATDB10}"
+        -P "${ETH_SCRIPTS_DIR}/buildinfo.cmake"
+        )
+    include_directories(BEFORE ${PROJECT_BINARY_DIR})
+endfunction()

--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -1,0 +1,132 @@
+#------------------------------------------------------------------------------
+# Setting compiling for FISCO-BCOS.
+# ------------------------------------------------------------------------------
+# This file is part of FISCO-BCOS.
+#
+# FISCO-BCOS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FISCO-BCOS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2018 fisco-dev contributors.
+#------------------------------------------------------------------------------
+
+# common settings
+set(ETH_CMAKE_DIR ${CMAKE_CURRENT_LIST_DIR})
+set(ETH_SCRIPTS_DIR ${ETH_CMAKE_DIR}/scripts)
+
+if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
+    # Use ISO C++11 standard language.
+    set(CMAKE_CXX_FLAGS -std=c++11)
+
+    # Enables all the warnings about constructions that some users consider questionable,
+    # and that are easy to avoid.  Also enable some extra warning flags that are not
+    # enabled by -Wall.   Finally, treat at warnings-as-errors, which forces developers
+    # to fix warnings as they arise, so they don't accumulate "to be fixed later".
+    add_compile_options(-Wall)
+    add_compile_options(-Wno-unused-variable)
+    add_compile_options(-Wno-missing-field-initializers)
+    add_compile_options(-Wno-unused-parameter)
+    add_compile_options(-Wextra)
+    # for boost json spirit
+    add_compile_options(-DBOOST_SPIRIT_THREADSAFE)
+    # for easy log
+    add_compile_options(-DELPP_THREAD_SAFE)
+
+    add_compile_options(-Wa,-march=generic64)
+
+    if(STATIC_BUILD)
+        SET(BUILD_SHARED_LIBRARIES OFF)
+        SET(CMAKE_EXE_LINKER_FLAGS "-static")
+    endif ()
+
+    # Disable warnings about unknown pragmas (which is enabled by -Wall).
+    add_compile_options(-Wno-unknown-pragmas)
+    
+    add_compile_options(-fno-omit-frame-pointer)
+
+	# Configuration-specific compiler settings.
+    set(CMAKE_CXX_FLAGS_DEBUG          "-Og -g -DETH_DEBUG -DELPP_THREAD_SAFE")
+    set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG -DETH_RELEASE -DELPP_THREAD_SAFE")
+    set(CMAKE_CXX_FLAGS_RELEASE        "-O3 -DNDEBUG -DETH_RELEASE -DELPP_THREAD_SAFE")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DETH_RELEASE -DELPP_THREAD_SAFE")
+
+    option(USE_LD_GOLD "Use GNU gold linker" ON)
+    if (USE_LD_GOLD)
+        execute_process(COMMAND ${CMAKE_C_COMPILER} -fuse-ld=gold -Wl,--version ERROR_QUIET OUTPUT_VARIABLE LD_VERSION)
+        if ("${LD_VERSION}" MATCHES "GNU gold")
+            set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold")
+            set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=gold")
+        endif ()
+    endif ()
+
+    # Additional GCC-specific compiler settings.
+    if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+
+        # Check that we've got GCC 4.7 or newer.
+        execute_process(
+            COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+        if (NOT (GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7))
+            message(FATAL_ERROR "${PROJECT_NAME} requires g++ 4.7 or greater.")
+        endif ()
+
+		# Strong stack protection was only added in GCC 4.9.
+		# Use it if we have the option to do so.
+		# See https://lwn.net/Articles/584225/
+        if (GCC_VERSION VERSION_GREATER 4.9 OR GCC_VERSION VERSION_EQUAL 4.9)
+            add_compile_options(-fstack-protector-strong)
+            add_compile_options(-fstack-protector)
+        endif()
+    # Additional Clang-specific compiler settings.
+    elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+        add_compile_options(-fstack-protector)
+        # Some Linux-specific Clang settings.  We don't want these for OS X.
+        if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+            # Tell Boost that we're using Clang's libc++.   Not sure exactly why we need to do.
+            add_definitions(-DBOOST_ASIO_HAS_CLANG_LIBCXX)
+            # Use fancy colors in the compiler diagnostics
+            add_compile_options(-fcolor-diagnostics)
+        endif()
+    endif()
+# If you don't have GCC, Clang then you are on your own.  Good luck!
+else ()
+    message(WARNING "Your compiler is not tested, if you run into any issues, we'd welcome any patches.")
+endif ()
+
+if (SANITIZE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=${SANITIZE}")
+    if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+        set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fsanitize-blacklist=${CMAKE_SOURCE_DIR}/sanitizer-blacklist.txt")
+    endif()
+endif()
+
+if (PROFILING AND (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")))
+    set(CMAKE_CXX_FLAGS "-g ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_C_FLAGS "-g ${CMAKE_C_FLAGS}")
+    add_definitions(-DETH_PROFILING_GPERF)
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lprofiler")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lprofiler")
+endif ()
+
+if (COVERAGE)
+    set(CMAKE_CXX_FLAGS "-g --coverage ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_C_FLAGS "-g --coverage ${CMAKE_C_FLAGS}")
+    set(CMAKE_SHARED_LINKER_FLAGS "--coverage ${CMAKE_SHARED_LINKER_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "--coverage ${CMAKE_EXE_LINKER_FLAGS}")
+    find_program(LCOV_TOOL lcov)
+    message(STATUS "lcov tool: ${LCOV_TOOL}")
+    if (LCOV_TOOL)
+        add_custom_target(coverage.info
+            COMMAND ${LCOV_TOOL} -o ${CMAKE_BINARY_DIR}/coverage.info -c -d ${CMAKE_BINARY_DIR}
+            COMMAND ${LCOV_TOOL} -o ${CMAKE_BINARY_DIR}/coverage.info -r ${CMAKE_BINARY_DIR}/coverage.info '/usr*' '${CMAKE_BINARY_DIR}/deps/*' '${CMAKE_SOURCE_DIR}/deps/*'
+    )
+    endif()
+endif ()

--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -1,0 +1,55 @@
+#------------------------------------------------------------------------------
+# all dependencies that are not directly included in the FISCO-BCOS distribution are defined here
+# for this to work, download the dependency via the cmake script in extdep or install them manually!
+# ------------------------------------------------------------------------------
+# This file is part of FISCO-BCOS.
+#
+# FISCO-BCOS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FISCO-BCOS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2018 fisco-dev contributors.
+#------------------------------------------------------------------------------
+
+function(eth_show_dependency DEP NAME)
+    get_property(DISPLAYED GLOBAL PROPERTY ETH_${DEP}_DISPLAYED)
+    if (NOT DISPLAYED)
+        set_property(GLOBAL PROPERTY ETH_${DEP}_DISPLAYED TRUE)
+        message(STATUS "${NAME} headers: ${${DEP}_INCLUDE_DIRS}")
+        message(STATUS "${NAME} lib   : ${${DEP}_LIBRARIES}")
+        if (NOT("${${DEP}_DLLS}" STREQUAL ""))
+            message(STATUS "${NAME} dll   : ${${DEP}_DLLS}")
+        endif() 
+    endif()
+endfunction()
+
+function(eth_use TARGET REQUIRED)
+    if (NOT TARGET ${TARGET})
+        message(FATAL_ERROR "eth_use called for non existing target ${TARGET}")
+    endif()
+
+    foreach(MODULE ${ARGN})
+        string(REPLACE "::" ";" MODULE_PARTS "${MODULE}")
+        list(GET MODULE_PARTS 0 MODULE_MAIN)
+        list(LENGTH MODULE_PARTS MODULE_LENGTH)
+        if (MODULE_LENGTH GREATER 1)
+            list(GET MODULE_PARTS 1 MODULE_SUB)
+        endif()
+        # TODO: check if file exists if not, throws FATAL_ERROR with detailed description
+        get_target_property(TARGET_APPLIED ${TARGET} TARGET_APPLIED_${MODULE_MAIN}_${MODULE_SUB})
+        if (NOT TARGET_APPLIED)
+            include(Use${MODULE_MAIN})
+            set_target_properties(${TARGET} PROPERTIES TARGET_APPLIED_${MODULE_MAIN}_${MODULE_SUB} TRUE)
+            eth_apply(${TARGET} ${REQUIRED} ${MODULE_SUB})
+        endif()
+    endforeach()
+endfunction()

--- a/cmake/EthOptions.cmake
+++ b/cmake/EthOptions.cmake
@@ -1,0 +1,93 @@
+#------------------------------------------------------------------------------
+# Set compile options for FISCO-BCOS.
+# ------------------------------------------------------------------------------
+# This file is part of FISCO-BCOS.
+#
+# FISCO-BCOS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FISCO-BCOS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2018 fisco-dev contributors.
+#------------------------------------------------------------------------------
+macro(eth_default_option O DEF)
+    if (DEFINED ${O})
+        if (${${O}})
+            set(${O} ON)
+        else ()
+            set(${O} OFF)
+        endif()
+    else ()
+        set(${O} ${DEF})
+    endif()
+endmacro()
+
+macro(configure_project)
+     set(NAME ${PROJECT_NAME})
+
+    # Default to RelWithDebInfo configuration if no configuration is explicitly specified.
+    if (NOT CMAKE_BUILD_TYPE)
+        set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
+            "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
+    endif()
+
+    eth_default_option(BUILD_SHARED_LIBS OFF)
+   
+    #ARCH TYPE
+    eth_default_option(STATIC_BUILD OFF)
+    eth_default_option(ARCH_TYPE OFF)
+    # unit tests
+    eth_default_option(TESTS OFF)
+    
+    # Define a matching property name of each of the "features".
+    foreach(FEATURE ${ARGN})
+        set(SUPPORT_${FEATURE} TRUE)
+    endforeach()
+
+    # CI Builds should provide (for user builds this is totally optional)
+    # -DBUILD_NUMBER - A number to identify the current build with. Becomes TWEAK component of project version.
+    # -DVERSION_SUFFIX - A string to append to the end of the version string where applicable.
+    if (NOT DEFINED BUILD_NUMBER)
+        # default is big so that local build is always considered greater
+        # and can easily replace CI build for for all platforms if needed.
+        # Windows max version component number is 65535
+        set(BUILD_NUMBER 65535)
+    endif()
+
+    # Suffix like "-rc1" e.t.c. to append to versions wherever needed.
+    if (NOT DEFINED VERSION_SUFFIX)
+        set(VERSION_SUFFIX "")
+    endif()
+
+    include(EthBuildInfo)
+    create_build_info()
+    print_config(${NAME})
+endmacro()
+
+macro(print_config NAME)
+    message("")
+    message("------------------------------------------------------------------------")
+    message("-- Configuring ${NAME}")
+    message("------------------------------------------------------------------------")
+    message("-- CMake ${CMAKE_VERSION} (${CMAKE_COMMAND})")
+    message("-- CMAKE_BUILD_TYPE Build type                               ${CMAKE_BUILD_TYPE}")
+    message("-- TARGET_PLATFORM  Target platform                          ${CMAKE_SYSTEM_NAME}")
+    message("-- STATIC_BUILD                                              ${STATIC_BUILD}")
+    message("-- ARCH_TYPE                                                 ${ARCH_TYPE}")
+    message("--------------------------------------------------------------- features")
+    message("------------------------------------------------------------- components")
+if (SUPPORT_TESTS)
+    message("-- TESTS            Build tests                              ${TESTS}")
+endif()
+    message("------------------------------------------------------------------------")
+    message("")
+endmacro()
+

--- a/cmake/EthUtils.cmake
+++ b/cmake/EthUtils.cmake
@@ -1,0 +1,41 @@
+#------------------------------------------------------------------------------
+# define public used function
+# 
+# renames the file if it is different from its destination
+# ------------------------------------------------------------------------------
+# This file is part of FISCO-BCOS.
+#
+# FISCO-BCOS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FISCO-BCOS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2018 fisco-dev contributors.
+#------------------------------------------------------------------------------
+macro(replace_if_different SOURCE DST)
+    set(extra_macro_args ${ARGN})
+    set(options CREATE)
+    set(one_value_args)
+    set(multi_value_args)
+    cmake_parse_arguments(REPLACE_IF_DIFFERENT "${options}" "${one_value_args}" "${multi_value_args}" "${extra_macro_args}")
+
+    if (REPLACE_IF_DIFFERENT_CREATE AND (NOT (EXISTS "${DST}")))
+        file(WRITE "${DST}" "")
+    endif()
+
+    execute_process(COMMAND ${CMAKE_COMMAND} -E compare_files "${SOURCE}" "${DST}" RESULT_VARIABLE DIFFERENT OUTPUT_QUIET ERROR_QUIET)
+
+    if (DIFFERENT)
+        execute_process(COMMAND ${CMAKE_COMMAND} -E rename "${SOURCE}" "${DST}")
+    else()
+    execute_process(COMMAND ${CMAKE_COMMAND} -E remove "${SOURCE}")
+    endif()
+endmacro()

--- a/cmake/FindMHD.cmake
+++ b/cmake/FindMHD.cmake
@@ -1,0 +1,47 @@
+#------------------------------------------------------------------------------
+# Find microhttpd
+# Find the microhttpd includes and library
+# if you need to add a custom library search path, do it via via CMAKE_PREFIX_PATH
+#
+# This module defines
+#  MHD_INCLUDE_DIRS, where to find header, etc.
+#  MHD_LIBRARIES, the libraries needed to use jsoncpp.
+#  MHD_FOUND, If false, do not try to use jsoncpp.
+# ------------------------------------------------------------------------------
+# This file is part of FISCO-BCOS.
+#
+# FISCO-BCOS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FISCO-BCOS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2018 fisco-dev contributors.
+#------------------------------------------------------------------------------
+find_path(
+    MHD_INCLUDE_DIR
+    NAMES microhttpd.h
+    DOC "microhttpd include dir"
+)
+
+find_library(
+    MHD_LIBRARY
+    NAMES microhttpd microhttpd-10 libmicrohttpd libmicrohttpd-dll
+    DOC "microhttpd library"
+)
+
+set(MHD_INCLUDE_DIRS ${MHD_INCLUDE_DIR})
+set(MHD_LIBRARIES ${MHD_LIBRARY})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(mhd DEFAULT_MSG
+    MHD_LIBRARY MHD_INCLUDE_DIR)
+
+mark_as_advanced(MHD_INCLUDE_DIR MHD_LIBRARY)

--- a/cmake/ProjectBoost.cmake
+++ b/cmake/ProjectBoost.cmake
@@ -57,10 +57,6 @@ ExternalProject_Add(boost
     INSTALL_COMMAND ""
 )
 
-if (ENCRYPTTYPE)
-    add_dependencies(boost tassl)
-endif()
-
 ExternalProject_Get_Property(boost SOURCE_DIR)
 set(BOOST_INCLUDE_DIR ${SOURCE_DIR})
 set(BOOST_LIB_DIR ${SOURCE_DIR}/stage/lib)

--- a/cmake/ProjectBoost.cmake
+++ b/cmake/ProjectBoost.cmake
@@ -1,0 +1,101 @@
+#------------------------------------------------------------------------------
+# install boost_1_63_0.tar.gz (located in deps/src/boost_1_63_0.tgz)
+# ------------------------------------------------------------------------------
+# This file is part of FISCO-BCOS.
+#
+# FISCO-BCOS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FISCO-BCOS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2018 fisco-dev contributors.
+#------------------------------------------------------------------------------
+include(ExternalProject)
+include(GNUInstallDirs)
+
+set(BOOST_CXXFLAGS "")
+set(BOOST_BOOTSTRAP_COMMAND ./bootstrap.sh)
+set(BOOST_BUILD_TOOL ./b2)
+set(BOOST_LIBRARY_SUFFIX .a)
+if (${BUILD_SHARED_LIBS})
+    set(BOOST_CXXFLAGS "cxxflags=-fPIC")
+endif()
+
+set(BOOST_CXXFLAGS "cxxflags=-Wa,-march=generic64")
+
+set(CMAKE_ARGS -DOPENSSL_INCLUDE_DIRS=${OPENSSL_INCLUDE_DIRS})
+ExternalProject_Add(boost
+    PREFIX ${CMAKE_SOURCE_DIR}/deps
+    DOWNLOAD_NO_PROGRESS 1
+    URL https://github.com/FISCO-BCOS/FISCO-BCOS/raw/master/deps/src/boost_1_63_0.tar.gz
+    URL_HASH SHA256=eb4c6f7e4e11905e1a98619f8a664dc4dca2d477bc985cfaf94463eef83a1aaa
+    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND ${BOOST_BOOTSTRAP_COMMAND}
+    LOG_CONFIGURE 1
+    BUILD_COMMAND ${BOOST_BUILD_TOOL} stage
+        ${BOOST_CXXFLAGS}
+        threading=multi
+        link=static
+        variant=release
+        address-model=64
+        --with-chrono
+        --with-date_time
+        --with-filesystem
+        --with-random
+        --with-regex
+        --with-test
+        --with-thread
+    LOG_BUILD 1
+    INSTALL_COMMAND ""
+)
+
+if (ENCRYPTTYPE)
+    add_dependencies(boost tassl)
+endif()
+
+ExternalProject_Get_Property(boost SOURCE_DIR)
+set(BOOST_INCLUDE_DIR ${SOURCE_DIR})
+set(BOOST_LIB_DIR ${SOURCE_DIR}/stage/lib)
+unset(BUILD_DIR)
+
+add_library(Boost::Chrono STATIC IMPORTED)
+set_property(TARGET Boost::Chrono PROPERTY IMPORTED_LOCATION ${BOOST_LIB_DIR}/libboost_chrono${BOOST_LIBRARY_SUFFIX})
+add_dependencies(Boost::Chrono boost)
+
+add_library(Boost::DataTime STATIC IMPORTED)
+set_property(TARGET Boost::DataTime PROPERTY IMPORTED_LOCATION ${BOOST_LIB_DIR}/libboost_date_time${BOOST_LIBRARY_SUFFIX})
+add_dependencies(Boost::DataTime boost)
+
+add_library(Boost::Regex STATIC IMPORTED)
+set_property(TARGET Boost::Regex PROPERTY IMPORTED_LOCATION ${BOOST_LIB_DIR}/libboost_regex${BOOST_LIBRARY_SUFFIX})
+add_dependencies(Boost::Regex boost)
+
+add_library(Boost::System STATIC IMPORTED)
+set_property(TARGET Boost::System PROPERTY IMPORTED_LOCATION ${BOOST_LIB_DIR}/libboost_system${BOOST_LIBRARY_SUFFIX})
+add_dependencies(Boost::System boost)
+
+add_library(Boost::Filesystem STATIC IMPORTED)
+set_property(TARGET Boost::Filesystem PROPERTY IMPORTED_LOCATION ${BOOST_LIB_DIR}/libboost_filesystem${BOOST_LIBRARY_SUFFIX})
+set_property(TARGET Boost::Filesystem PROPERTY INTERFACE_LINK_LIBRARIES Boost::System)
+add_dependencies(Boost::Filesystem boost)
+
+add_library(Boost::Random STATIC IMPORTED)
+set_property(TARGET Boost::Random PROPERTY IMPORTED_LOCATION ${BOOST_LIB_DIR}/libboost_random${BOOST_LIBRARY_SUFFIX})
+add_dependencies(Boost::Random boost)
+
+add_library(Boost::UnitTestFramework STATIC IMPORTED)
+set_property(TARGET Boost::UnitTestFramework PROPERTY IMPORTED_LOCATION ${BOOST_LIB_DIR}/libboost_unit_test_framework${BOOST_LIBRARY_SUFFIX})
+add_dependencies(Boost::UnitTestFramework boost)
+
+add_library(Boost::Thread STATIC IMPORTED)
+set_property(TARGET Boost::Thread PROPERTY IMPORTED_LOCATION ${BOOST_LIB_DIR}/libboost_thread${BOOST_LIBRARY_SUFFIX})
+set_property(TARGET Boost::Thread PROPERTY INTERFACE_LINK_LIBRARIES Boost::Chrono Boost::DataTime Boost::Regex)
+add_dependencies(Boost::Thread boost)

--- a/cmake/ProjectCryptopp.cmake
+++ b/cmake/ProjectCryptopp.cmake
@@ -1,0 +1,162 @@
+#------------------------------------------------------------------------------
+# install cryptopp
+# @ ${CRYPTOPP_LIBRARY}: cryptopp library path;
+# @ ${CRYPTOPP_INCLUDE_DIR}: cryptopp include path.
+# ------------------------------------------------------------------------------
+# This file is part of FISCO-BCOS.
+#
+# FISCO-BCOS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FISCO-BCOS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2018 fisco-dev contributors.
+#------------------------------------------------------------------------------
+
+include(ExternalProject)
+include(GNUInstallDirs)
+
+ExternalProject_Add(cryptopp
+    PREFIX ${CMAKE_SOURCE_DIR}/deps
+    # This points to unreleased version 5.6.5+ but contains very small
+    # warning fix:
+    # https://github.com/weidai11/cryptopp/commit/903b8feaa70199eb39a313b32a71268745ddb600
+    DOWNLOAD_NAME cryptopp_bccc6443.tar.gz
+    DOWNLOAD_NO_PROGRESS 1
+    URL https://github.com/weidai11/cryptopp/archive/bccc6443c4d4d611066c2de4c17109380cf97704.tar.gz
+    URL_HASH SHA256=f1fddacadd2a0873f795d5614a85fecd5b6ff1d1c6e21dedc251703c54ce63aa
+    PATCH_COMMAND ${CMAKE_COMMAND} -E remove
+        3way.cpp
+        adler32.cpp
+        arc4.cpp
+        authenc.cpp
+        base32.cpp
+        base64.cpp
+        bench1.cpp
+        bench2.cpp
+        bfinit.cpp
+        blake2.cpp
+        blowfish.cpp
+        blumshub.cpp
+        camellia.cpp
+        cast.cpp
+        casts.cpp
+        cbcmac.cpp
+        ccm.cpp
+        chacha.cpp
+        channels.cpp
+        cmac.cpp
+        crc.cpp
+        datatest.cpp
+        default.cpp
+        des.cpp
+        dessp.cpp
+        dh2.cpp
+        dh.cpp
+        dlltest.cpp
+        eax.cpp
+        elgamal.cpp
+        emsa2.cpp
+        esign.cpp
+        files.cpp
+        fipsalgt.cpp
+        fipstest.cpp
+        gcm.cpp
+        gf2_32.cpp
+        gf256.cpp
+        gost.cpp
+        gzip.cpp
+        ida.cpp
+        idea.cpp
+        luc.cpp
+        mars.cpp
+        marss.cpp
+        md2.cpp
+        md4.cpp
+        md5.cpp
+        mqv.cpp
+        network.cpp
+        panama.cpp
+        pch.cpp
+        pkcspad.cpp
+        poly1305.cpp
+        pssr.cpp
+        rabin.cpp
+        rc2.cpp
+        rc5.cpp
+        rc6.cpp
+        rdrand.cpp
+        regtest.cpp
+        ripemd.cpp
+        rsa.cpp
+        rw.cpp
+        safer.cpp
+        salsa.cpp
+        seal.cpp
+        seed.cpp
+        serpent.cpp
+        sha3.cpp
+        shacal2.cpp
+        sharkbox.cpp
+        shark.cpp
+        simple.cpp
+        skipjack.cpp
+        socketft.cpp
+        sosemanuk.cpp
+        square.cpp
+        squaretb.cpp
+        tea.cpp
+        test.cpp
+        tftables.cpp
+        tiger.cpp
+        tigertab.cpp
+        trdlocal.cpp
+        ttmac.cpp
+        twofish.cpp
+        validat0.cpp
+        validat1.cpp
+        validat2.cpp
+        validat3.cpp
+        vmac.cpp
+        wait.cpp
+        wake.cpp
+        whrlpool.cpp
+        xtr.cpp
+        xtrcrypt.cpp
+        zdeflate.cpp
+        zinflate.cpp
+        zlib.cpp
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        -DCMAKE_BUILD_TYPE=Release
+        # Build static lib but suitable to be included in a shared lib.
+        -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
+        -DBUILD_SHARED=Off
+        -DBUILD_TESTING=Off
+        -DCMAKE_C_FLAGS=-Wa,-march=generic64
+        -DCMAKE_CXX_FLAGS=-Wa,-march=generic64
+        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+    LOG_CONFIGURE 1
+    BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
+    INSTALL_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release --target install
+    LOG_INSTALL 1
+)
+
+ExternalProject_Get_Property(cryptopp INSTALL_DIR)
+add_library(Cryptopp STATIC IMPORTED)
+
+set(CRYPTOPP_LIBRARY ${INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}cryptopp${CMAKE_STATIC_LIBRARY_SUFFIX})
+set(CRYPTOPP_INCLUDE_DIR ${INSTALL_DIR}/include)
+file(MAKE_DIRECTORY ${CRYPTOPP_INCLUDE_DIR})  # Must exist.
+set_property(TARGET Cryptopp PROPERTY IMPORTED_LOCATION ${CRYPTOPP_LIBRARY})
+set_property(TARGET Cryptopp PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${CRYPTOPP_INCLUDE_DIR})
+add_dependencies(Cryptopp cryptopp)
+unset(INSTALL_DIR)

--- a/cmake/ProjectJsonCpp.cmake
+++ b/cmake/ProjectJsonCpp.cmake
@@ -1,0 +1,63 @@
+#------------------------------------------------------------------------------
+# install json cpp from git
+# @ ${JSONCPP_INCLUDE_DIR}: jsoncpp include path
+# @ ${JSONCPP_LIBRARY}: jsoncpp libbrary path
+# ------------------------------------------------------------------------------
+# This file is part of FISCO-BCOS.
+#
+# FISCO-BCOS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FISCO-BCOS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2018 fisco-dev contributors.
+#------------------------------------------------------------------------------
+include(ExternalProject)
+
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
+    set(JSONCPP_CMAKE_COMMAND emcmake cmake)
+else()
+    set(JSONCPP_CMAKE_COMMAND ${CMAKE_COMMAND})
+endif()
+
+ExternalProject_Add(jsoncpp
+    PREFIX ${CMAKE_SOURCE_DIR}/deps
+    DOWNLOAD_NAME jsoncpp-1.7.7.tar.gz
+    DOWNLOAD_NO_PROGRESS 1
+    URL https://github.com/open-source-parsers/jsoncpp/archive/1.7.7.tar.gz
+    URL_HASH SHA256=087640ebcf7fbcfe8e2717a0b9528fff89c52fcf69fa2a18cc2b538008098f97
+    CMAKE_COMMAND ${JSONCPP_CMAKE_COMMAND}
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+               # Build static lib but suitable to be included in a shared lib.
+               -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
+               ${_only_release_configuration}
+               -DJSONCPP_WITH_TESTS=Off
+               -DJSONCPP_WITH_PKGCONFIG_SUPPORT=Off
+               	-DCMAKE_C_FLAGS=-Wa,-march=generic64
+               	-DCMAKE_CXX_FLAGS=-Wa,-march=generic64
+               	-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+        		-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+    LOG_CONFIGURE 1
+    BUILD_COMMAND ""
+    ${_overwrite_install_command}
+    LOG_INSTALL 1
+)
+
+# Create jsoncpp imported library
+ExternalProject_Get_Property(jsoncpp INSTALL_DIR)
+add_library(JsonCpp STATIC IMPORTED)
+set(JSONCPP_LIBRARY ${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX})
+set(JSONCPP_INCLUDE_DIR ${INSTALL_DIR}/include)
+file(MAKE_DIRECTORY ${JSONCPP_INCLUDE_DIR})  # Must exist.
+set_property(TARGET JsonCpp PROPERTY IMPORTED_LOCATION ${JSONCPP_LIBRARY})
+set_property(TARGET JsonCpp PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${JSONCPP_INCLUDE_DIR})
+add_dependencies(JsonCpp jsoncpp)
+unset(INSTALL_DIR)

--- a/cmake/ProjectJsonRpcCpp.cmake
+++ b/cmake/ProjectJsonRpcCpp.cmake
@@ -1,0 +1,97 @@
+#------------------------------------------------------------------------------
+# HTTP client from JSON RPC CPP requires curl library. It can find it itself,
+# but we need to know the libcurl location for static linking. 
+#
+# HTTP server from JSON RPC CPP requires microhttpd library. It can find it itself,
+# but we need to know the MHD location for static linking.
+# ------------------------------------------------------------------------------
+# This file is part of FISCO-BCOS.
+#
+# FISCO-BCOS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FISCO-BCOS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2018 fisco-dev contributors.
+#------------------------------------------------------------------------------
+find_package(CURL REQUIRED)
+find_package(MHD REQUIRED)
+set(CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+               -DCMAKE_BUILD_TYPE=Release
+               # Build static lib but suitable to be included in a shared lib.
+               -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
+               -DBUILD_STATIC_LIBS=On
+               -DBUILD_SHARED_LIBS=Off
+               -DUNIX_DOMAIN_SOCKET_SERVER=Off
+               -DUNIX_DOMAIN_SOCKET_CLIENT=Off
+               -DHTTP_SERVER=On
+               -DHTTP_CLIENT=On
+               -DCOMPILE_TESTS=Off
+               -DCOMPILE_STUBGEN=Off
+               -DCOMPILE_EXAMPLES=Off
+               # Point to jsoncpp library.
+               -DJSONCPP_INCLUDE_DIR=${JSONCPP_INCLUDE_DIR}
+               # Select jsoncpp include prefix: <json/...> or <jsoncpp/json/...>
+               -DJSONCPP_INCLUDE_PREFIX=json
+               -DJSONCPP_LIBRARY=${JSONCPP_LIBRARY}
+               -DCURL_INCLUDE_DIR=${CURL_INCLUDE_DIR}
+               -DCURL_LIBRARY=${CURL_LIBRARY}
+               -DMHD_INCLUDE_DIR=${MHD_INCLUDE_DIR}
+               -DMHD_LIBRARY=${MHD_LIBRARY}
+               -DCMAKE_C_FLAGS=-Wa,-march=generic64
+               -DCMAKE_CXX_FLAGS=-Wa,-march=generic64
+               -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+               )
+
+
+ExternalProject_Add(jsonrpccpp
+    PREFIX ${CMAKE_SOURCE_DIR}/deps
+    DOWNLOAD_NAME jsonrcpcpp-0.7.0.tar.gz
+    DOWNLOAD_NO_PROGRESS 1
+    URL https://github.com/cinemast/libjson-rpc-cpp/archive/v0.7.0.tar.gz
+    URL_HASH SHA256=669c2259909f11a8c196923a910f9a16a8225ecc14e6c30e2bcb712bab9097eb
+    # On Windows it tries to install this dir. Create it to prevent failure.
+    PATCH_COMMAND ${CMAKE_COMMAND} -E make_directory <SOURCE_DIR>/win32-deps/include
+    CMAKE_ARGS ${CMAKE_ARGS}
+    LOG_CONFIGURE 1
+    BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
+    INSTALL_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release --target install
+    LOG_INSTALL 1
+)
+
+add_dependencies(jsonrpccpp jsoncpp)
+
+ExternalProject_Get_Property(jsonrpccpp INSTALL_DIR)
+set(JSONRPCCPP_INCLUDE_DIR ${INSTALL_DIR}/include)
+file(MAKE_DIRECTORY ${JSONRPCCPP_INCLUDE_DIR})  # Must exist.
+
+add_library(JsonRpcCpp::Common STATIC IMPORTED)
+set_property(TARGET JsonRpcCpp::Common PROPERTY IMPORTED_LOCATION ${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}jsonrpccpp-common${CMAKE_STATIC_LIBRARY_SUFFIX})
+set_property(TARGET JsonRpcCpp::Common PROPERTY INTERFACE_LINK_LIBRARIES JsonCpp)
+set_property(TARGET JsonRpcCpp::Common PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${JSONRPCCPP_INCLUDE_DIR} ${JSONCPP_INCLUDE_DIR})
+add_dependencies(JsonRpcCpp::Common jsonrpccpp)
+
+add_library(JsonRpcCpp::Client STATIC IMPORTED)
+set_property(TARGET JsonRpcCpp::Client PROPERTY IMPORTED_LOCATION ${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}jsonrpccpp-client${CMAKE_STATIC_LIBRARY_SUFFIX})
+set_property(TARGET JsonRpcCpp::Client PROPERTY INTERFACE_LINK_LIBRARIES JsonRpcCpp::Common ${CURL_LIBRARY})
+set_property(TARGET JsonRpcCpp::Client PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${CURL_INCLUDE_DIR})
+add_dependencies(JsonRpcCpp::Client jsonrpccpp)
+
+add_library(JsonRpcCpp::Server STATIC IMPORTED)
+set_property(TARGET JsonRpcCpp::Server PROPERTY IMPORTED_LOCATION ${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}jsonrpccpp-server${CMAKE_STATIC_LIBRARY_SUFFIX})
+set_property(TARGET JsonRpcCpp::Server PROPERTY INTERFACE_LINK_LIBRARIES JsonRpcCpp::Common ${MHD_LIBRARY})
+set_property(TARGET JsonRpcCpp::Server PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${MHD_INCLUDE_DIR})
+add_dependencies(JsonRpcCpp::Server jsonrpccpp)
+
+unset(BINARY_DIR)
+unset(INSTALL_DIR)
+unset(CMAKE_ARGS)

--- a/cmake/ProjectSecp256k1.cmake
+++ b/cmake/ProjectSecp256k1.cmake
@@ -1,0 +1,56 @@
+#------------------------------------------------------------------------------
+# install secp256k1
+# @ ${SECP256K1_LIBRARY}: library path of secp256k1;
+# @ ${SECP256K1_INCLUDE_DIR}: include path of secp256k1.
+# ------------------------------------------------------------------------------
+# This file is part of FISCO-BCOS.
+#
+# FISCO-BCOS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FISCO-BCOS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2018 fisco-dev contributors.
+#------------------------------------------------------------------------------
+
+include(ExternalProject)
+
+ExternalProject_Add(secp256k1
+    PREFIX ${CMAKE_SOURCE_DIR}/deps
+    DOWNLOAD_NAME secp256k1-9d560f99.tar.gz
+    DOWNLOAD_NO_PROGRESS 1
+    URL https://github.com/bitcoin-core/secp256k1/archive/9d560f992db26612ce2630b194aef5f44d63a530.tar.gz
+    URL_HASH SHA256=910b2535bdbb5d235e9212c92050e0f9b327e05129b449f8f3d3c6d558121284
+    PATCH_COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${CMAKE_CURRENT_LIST_DIR}/secp256k1/CMakeLists.txt <SOURCE_DIR>
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+               -DCMAKE_POSITION_INDEPENDENT_CODE=${BUILD_SHARED_LIBS}
+               ${_only_release_configuration}
+               -DCMAKE_C_FLAGS=-Wa,-march=generic64
+               -DCMAKE_CXX_FLAGS=-Wa,-march=generic64
+               -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+               -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+    LOG_CONFIGURE 1
+    BUILD_COMMAND ""
+    ${_overwrite_install_command}
+    LOG_INSTALL 1
+)
+
+# Create imported library
+ExternalProject_Get_Property(secp256k1 INSTALL_DIR)
+add_library(Secp256k1 STATIC IMPORTED)
+set(SECP256K1_LIBRARY ${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}secp256k1${CMAKE_STATIC_LIBRARY_SUFFIX})
+set(SECP256K1_INCLUDE_DIR ${INSTALL_DIR}/include)
+file(MAKE_DIRECTORY ${SECP256K1_INCLUDE_DIR})  # Must exist.
+set_property(TARGET Secp256k1 PROPERTY IMPORTED_LOCATION ${SECP256K1_LIBRARY})
+set_property(TARGET Secp256k1 PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${SECP256K1_INCLUDE_DIR})
+add_dependencies(Secp256k1 secp256k1)
+unset(INSTALL_DIR)

--- a/cmake/scripts/buildinfo.cmake
+++ b/cmake/scripts/buildinfo.cmake
@@ -1,0 +1,64 @@
+#------------------------------------------------------------------------------
+# generates BuildInfo.h
+# 
+# this module expects
+# ETH_SOURCE_DIR - main CMAKE_SOURCE_DIR
+# ETH_DST_DIR - main CMAKE_BINARY_DIR
+# ETH_BUILD_TYPE
+# ETH_BUILD_PLATFORM
+# ETH_BUILD_NUMBER
+# ETH_VERSION_SUFFIX
+# ------------------------------------------------------------------------------
+# This file is part of FISCO-BCOS.
+#
+# FISCO-BCOS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FISCO-BCOS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2018 fisco-dev contributors.
+#------------------------------------------------------------------------------
+if (NOT ETH_BUILD_TYPE)
+    set(ETH_BUILD_TYPE "unknown")
+endif()
+
+if (NOT ETH_BUILD_PLATFORM)
+    set(ETH_BUILD_PLATFORM "unknown")
+endif()
+
+execute_process(
+    COMMAND git --git-dir=${ETH_SOURCE_DIR}/.git --work-tree=${ETH_SOURCE_DIR} rev-parse HEAD
+    OUTPUT_VARIABLE ETH_COMMIT_HASH OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET
+) 
+
+if (NOT ETH_COMMIT_HASH)
+    set(ETH_COMMIT_HASH 0)
+endif()
+
+execute_process(
+    COMMAND git --git-dir=${ETH_SOURCE_DIR}/.git --work-tree=${ETH_SOURCE_DIR} diff HEAD --shortstat
+    OUTPUT_VARIABLE ETH_LOCAL_CHANGES OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET
+)
+
+if (ETH_LOCAL_CHANGES)
+    set(ETH_CLEAN_REPO 0)
+else()
+    set(ETH_CLEAN_REPO 1)
+endif()
+
+set(TMPFILE "${ETH_DST_DIR}/BuildInfo.h.tmp")
+set(OUTFILE "${ETH_DST_DIR}/BuildInfo.h")
+
+configure_file("${ETH_BUILDINFO_IN}" "${TMPFILE}")
+
+include("${ETH_CMAKE_DIR}/EthUtils.cmake")
+replace_if_different("${TMPFILE}" "${OUTFILE}" CREATE)
+

--- a/cmake/secp256k1/CMakeLists.txt
+++ b/cmake/secp256k1/CMakeLists.txt
@@ -1,0 +1,56 @@
+#------------------------------------------------------------------------------
+# This CMake config file for secp256k1 project from https://github.com/bitcoin-core/secp256k1
+#
+# The secp256k1 project has been configured following official docs with following options:
+#
+# ./configure --disable-shared --disable-tests --disable-coverage --disable-openssl-tests --disable-exhaustive-tests --disable-jni --with-bignum=no --with-field=64bit --with-scalar=64bit --with-asm=no
+#
+# Build static context:
+# make src/ecmult_static_context.h
+#
+# Copy src/ecmult_static_context.h and src/libsecp256k1-config.h
+#
+# Copy CFLAGS from Makefile to COMPILE_OPTIONS.
+# ------------------------------------------------------------------------------
+# This file is part of FISCO-BCOS.
+#
+# FISCO-BCOS is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FISCO-BCOS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2016-2018 fisco-dev contributors.
+#------------------------------------------------------------------------------
+cmake_minimum_required(VERSION 3.4)
+project(secp256k1 LANGUAGES C)
+
+set(COMMON_COMPILE_FLAGS ENABLE_MODULE_RECOVERY USE_ECMULT_STATIC_PRECOMPUTATION USE_FIELD_INV_BUILTIN USE_NUM_NONE USE_SCALAR_INV_BUILTIN)
+if (MSVC)
+	set(COMPILE_FLAGS USE_FIELD_10X26 USE_SCALAR_8X32)
+	set(COMPILE_OPTIONS "")
+else()
+	set(COMPILE_FLAGS USE_FIELD_5X52 USE_SCALAR_4X64 HAVE_BUILTIN_EXPECT HAVE___INT128)
+	set(COMPILE_OPTIONS -O3 -W -std=c89 -pedantic -Wall -Wextra -Wcast-align -Wnested-externs -Wshadow -Wstrict-prototypes -Wno-unused-function -Wno-long-long -Wno-overlength-strings -fvisibility=hidden)
+endif()
+
+add_executable(gen_context src/gen_context.c)
+target_include_directories(gen_context PRIVATE ${CMAKE_SOURCE_DIR})
+
+add_custom_target(ecmult_static_context gen_context WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+add_library(secp256k1 STATIC src/secp256k1.c)
+target_compile_definitions(secp256k1 PRIVATE ${COMMON_COMPILE_FLAGS} ${COMPILE_FLAGS})
+target_include_directories(secp256k1 PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/src)
+target_compile_options(secp256k1 PRIVATE ${COMPILE_OPTIONS})
+add_dependencies(secp256k1 ecmult_static_context)
+
+install(TARGETS secp256k1 ARCHIVE DESTINATION lib)
+install(DIRECTORY include/ DESTINATION include)

--- a/cmake/templates/BuildInfo.h.in
+++ b/cmake/templates/BuildInfo.h.in
@@ -1,0 +1,35 @@
+// "Copyright [2018] <fisco-dev>"
+/*
+    This file is part of FISCO-BCOS
+    FISCO-BCOS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    FISCO-BCOS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** 
+ * @file: BuildInfo.h
+ * @author: fisco-dev
+ * @date: 2018
+ * build information template
+ */
+
+#pragma once
+
+#define ETH_PROJECT_VERSION "@PROJECT_VERSION@"
+#define ETH_COMMIT_HASH @ETH_COMMIT_HASH@
+#define ETH_CLEAN_REPO @ETH_CLEAN_REPO@
+#define ETH_BUILD_TYPE @ETH_BUILD_TYPE@
+#define ETH_BUILD_OS @ETH_BUILD_OS@
+#define ETH_BUILD_COMPILER @ETH_BUILD_COMPILER@
+#define ETH_BUILD_JIT_MODE @ETH_BUILD_JIT_MODE@
+#define ETH_BUILD_PLATFORM @ETH_BUILD_PLATFORM@
+#define ETH_BUILD_NUMBER @ETH_BUILD_NUMBER@
+#define ETH_VERSION_SUFFIX "@ETH_VERSION_SUFFIX@"

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,0 +1,106 @@
+ # "Copyright [2018] <fisco-dev>"
+ # @ function on-click install shell script(appliable for centos and ubuntu)
+ # @ Require: yum or apt, git are ready
+ # @ attention: if dependecies are downloaded failed, 
+ #              please fetch packages into "deps/src" from https://github.com/bcosorg/lib manually
+ #              and execute this shell script later
+ # @ author: fisco-dev  
+ # @ file: build.sh
+ # @ date: 2018
+
+#!/bin/sh
+set -e
+
+current_dir=`pwd`"/.."
+
+cd ${current_dir}
+
+LOG_ERROR() {
+    content=${1}
+    echo -e "\033[31m"${content}"\033[0m"
+}
+
+LOG_INFO() {
+    content=${1}
+    echo -e "\033[32m"${content}"\033[0m"
+}
+
+execute_cmd()
+{
+    command="${1}"
+    #LOG_INFO "RUN: ${command}"
+    eval ${command}
+    ret=$?
+    if [ $ret -ne 0 ];then
+        LOG_ERROR "FAILED execution of command: ${command}"
+        exit 1
+    else
+        LOG_INFO "SUCCESS execution of command: ${command}"
+    fi
+}
+
+install_ubuntu_package()
+{
+    for i in $@ ;
+    do 
+        LOG_INFO "install ${i}";
+        execute_cmd "sudo apt-get -y install ${i}";
+    done
+}
+
+install_centos_package()
+{
+    for i in $@ ;
+    do
+        LOG_INFO "install ${i}";
+        execute_cmd "yum -y install ${i}";
+    done
+}
+
+#install ubuntu package
+install_ubuntu_deps()
+{
+	install_ubuntu_package "cmake" "npm" "openssl" "libssl-dev" "libkrb5-dev"
+}
+
+# install centos package
+install_centos_deps()
+{
+	install_centos_package "cmake3" "gcc-c++" "openssl" "openssl-devel"
+}
+
+#=== install all deps
+install_all_deps()
+{
+    if grep -Eqi "Ubuntu" /etc/issue || grep -Eq "Ubuntu" /etc/*-release; then
+        install_ubuntu_deps
+    else
+        install_centos_deps
+    fi
+}
+
+build_ubuntu_source() {
+    # build source
+    execute_cmd "mkdir -p build && cd build/"
+    execute_cmd "cmake -DEVMJIT=OFF -DTESTS=OFF -DMINIUPNPC=OFF .. "
+    execute_cmd "make && make install"
+}
+
+build_centos_source() {
+    # build source
+    execute_cmd "mkdir -p build && cd build/"
+    execute_cmd "cmake3 -DEVMJIT=OFF -DTESTS=OFF -DMINIUPNPC=OFF .. "
+    execute_cmd "make -j2 && make install && cd ${current_dir}"
+}
+
+build_source() {
+    cd ${current_dir}
+    if grep -Eqi "Ubuntu" /etc/issue || grep -Eq "Ubuntu" /etc/*-release; then
+        build_ubuntu_source
+    else
+        build_centos_source
+    fi
+}
+
+install_all_deps
+build_source


### PR DESCRIPTION
添加最小依赖cmake：
1. 设置编译器和编译选项
2. 使用内置cmake 安装deps/src/目录下安装包
3. 生成BuildInfo.h头文件(以cmake/templates/BuildInfo.h.in为模板)