### PR TITLE
add DEBUG flag to EthOptions.cmake && remove useless functions and micro-definitions of Common.cpp of libdevcore && add unit tests for Common.* of libdevcore

### DIFF
--- a/cmake/EthOptions.cmake
+++ b/cmake/EthOptions.cmake
@@ -18,6 +18,12 @@
 #
 # (c) 2016-2018 fisco-dev contributors.
 #------------------------------------------------------------------------------
+# change-list
+# 2018/09/05: yujiechen
+# 1. add DEBUG flag
+# 2. add ETH_DEBUG definition when DEBUG flag has been set
+# 3. add ETH_TESTS definition when TESTS flag has been set
+
 macro(eth_default_option O DEF)
     if (DEFINED ${O})
         if (${${O}})
@@ -46,7 +52,16 @@ macro(configure_project)
     eth_default_option(ARCH_TYPE OFF)
     # unit tests
     eth_default_option(TESTS ON)
-    
+    if (TESTS)
+        add_definitions(-DETH_TESTS)
+    endif()
+
+    #debug
+    eth_default_option(DEBUG OFF)
+    if (DEBUG)
+        add_definitions(-DETH_DEBUG)
+    endif()
+
     # Define a matching property name of each of the "features".
     foreach(FEATURE ${ARGN})
         set(SUPPORT_${FEATURE} TRUE)

--- a/libdevcore/Common.cpp
+++ b/libdevcore/Common.cpp
@@ -61,43 +61,4 @@ uint64_t utcTime()
     gettimeofday(&tv, NULL);
     return tv.tv_sec * 1000 + tv.tv_usec / 1000;
 }
-
-string inUnits(bigint const& _b, strings const& _units)
-{
-    ostringstream ret;
-    u256 b;
-    if (_b < 0)
-    {
-        ret << "-";
-        b = (u256)-_b;
-    }
-    else
-        b = (u256)_b;
-
-    u256 biggest = 1;
-    for (unsigned i = _units.size() - 1; !!i; --i)
-        biggest *= 1000;
-
-    if (b > biggest * 1000)
-    {
-        ret << (b / biggest) << " " << _units.back();
-        return ret.str();
-    }
-    ret << setprecision(3);
-
-    u256 unit = biggest;
-    for (auto it = _units.rbegin(); it != _units.rend(); ++it)
-    {
-        auto i = *it;
-        if (i != _units.front() && b >= unit)
-        {
-            ret << (double(b / (unit / 1000)) / 1000.0) << " " << i;
-            return ret.str();
-        }
-        else
-            unit /= 1000;
-    }
-    ret << b << " " << _units.front();
-    return ret.str();
-}
 }  // namespace dev

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -23,6 +23,12 @@
  * @author wheatli
  * @date 2018.8.27
  * @modify add owning_bytes_ref
+ *
+ * @author yujiechen
+ * @data 2018.9.5
+ * @modify: remove useless micro-definition 'DEV_IF_THROWS'
+ *          remove useless functions: toLog2, inUnits
+ *          add ETH_TESTS flag to recover the DEV_INVARANIT_CHECK in both debug mode and test mode
  */
 
 #pragma once
@@ -66,13 +72,6 @@ using byte = uint8_t;
     catch (...)                  \
     {                            \
     }
-
-#define DEV_IF_THROWS(X) \
-    try                  \
-    {                    \
-        X;               \
-    }                    \
-    catch (...)
 
 namespace dev
 {
@@ -147,6 +146,7 @@ u256 constexpr Invalid256 =
 inline s256 u2s(u256 _u)
 {
     static const bigint c_end = bigint(1) << 256;
+    /// get the +/- symbols
     if (boost::multiprecision::bit_test(_u, 255))
         return s256(-(c_end - _u));
     else
@@ -163,18 +163,6 @@ inline u256 s2u(s256 _u)
         return u256(c_end + _u);
 }
 //-----------Common Convertions and Calcultations--------------------
-/// Converts given int to a string and appends one of a series of units according to its size.
-std::string inUnits(bigint const& _b, strings const& _units);
-
-/// @returns the smallest n >= 0 such that (1 << n) >= _x
-inline unsigned int toLog2(u256 _x)
-{
-    unsigned ret;
-    for (ret = 0; _x >>= 1; ++ret)
-    {
-    }
-    return ret;
-}
 
 template <size_t n>
 inline u256 exp10()
@@ -236,7 +224,7 @@ private:
 };
 
 /// Scope guard for invariant check in a class derived from HasInvariants.
-#if ETH_DEBUG
+#if (ETH_DEBUG || ETH_TESTS)
 #define DEV_INVARIANT_CHECK \
     ::dev::InvariantChecker __dev_invariantCheck(this, BOOST_CURRENT_FUNCTION, __FILE__, __LINE__)
 #define DEV_INVARIANT_CHECK_HERE \
@@ -270,6 +258,7 @@ public:
     {
         return std::chrono::high_resolution_clock::now() - m_t;
     }
+    /// return seconds
     double elapsed() const
     {
         return std::chrono::duration_cast<std::chrono::microseconds>(duration()).count() /

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -28,7 +28,6 @@
  * @date 2018.9.5
  * @modify: remove useless micro-definition 'DEV_IF_THROWS'
  *          remove useless functions: toLog2, inUnits
- *          add ETH_TESTS flag to recover the DEV_INVARANIT_CHECK in both debug mode and test mode
  */
 
 #pragma once
@@ -224,7 +223,7 @@ private:
 };
 
 /// Scope guard for invariant check in a class derived from HasInvariants.
-#if (ETH_DEBUG || ETH_TESTS)
+#if ETH_DEBUG
 #define DEV_INVARIANT_CHECK \
     ::dev::InvariantChecker __dev_invariantCheck(this, BOOST_CURRENT_FUNCTION, __FILE__, __LINE__)
 #define DEV_INVARIANT_CHECK_HERE \

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -25,7 +25,7 @@
  * @modify add owning_bytes_ref
  *
  * @author yujiechen
- * @data 2018.9.5
+ * @date 2018.9.5
  * @modify: remove useless micro-definition 'DEV_IF_THROWS'
  *          remove useless functions: toLog2, inUnits
  *          add ETH_TESTS flag to recover the DEV_INVARANIT_CHECK in both debug mode and test mode

--- a/test/unittests/libdevcore/Common.cpp
+++ b/test/unittests/libdevcore/Common.cpp
@@ -106,8 +106,10 @@ BOOST_AUTO_TEST_CASE(testCheckInvariants)
 {
     FakeCheckInvariants fake_invariant;
     BOOST_REQUIRE_NO_THROW(fake_invariant.check());
+#if ETH_DEBUG
     fake_invariant.setHasInvariants(false);
     BOOST_CHECK_THROW(fake_invariant.check(), FailedInvariant);
+#endif
 }
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace test

--- a/test/unittests/libdevcore/Common.cpp
+++ b/test/unittests/libdevcore/Common.cpp
@@ -1,0 +1,114 @@
+/**
+ * @CopyRight:
+ * FISCO-BCOS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * FISCO-BCOS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+ * (c) 2016-2018 fisco-dev contributors.
+ *
+ * @brief: unit test for Common.* of libdevcore
+ *
+ * @file Common.cpp
+ * @author: yujiechen
+ * @date 2018-08-24
+ */
+
+
+#include <libdevcore/Common.h>
+#include <libdevcore/Exceptions.h>
+#include <test/tools/libutils/TestOutputHelper.h>
+#include <unistd.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace dev;
+namespace dev
+{
+namespace test
+{
+BOOST_FIXTURE_TEST_SUITE(DevcoreCommonTest, TestOutputHelperFixture)
+BOOST_AUTO_TEST_CASE(testIgnoreExceptions)
+{
+    BOOST_REQUIRE_NO_THROW(DEV_IGNORE_EXCEPTIONS(10 / 0));
+}
+/// test Arith Calculations
+BOOST_AUTO_TEST_CASE(testArithCal)
+{
+    ///=========test u2s==================
+    u256 u_bigint("343894723987432");
+    bigint c_end = bigint(1) << 256;
+    BOOST_CHECK(u2s(u_bigint) == u_bigint);
+    u_bigint = Invalid256;
+    BOOST_CHECK(u2s(u_bigint) < s256(0));
+    u_bigint = u256("0xa170d8e0ae1b57d7ecc121f6fe5ceb03c1267801ff720edd2f8463e7effac6c6");
+    BOOST_CHECK(u2s(u_bigint) < s256(0));
+    BOOST_CHECK(u2s(u_bigint) == s256(-(c_end - u_bigint)));
+    u_bigint = u256("0x7170d8e0ae1b57d7ecc121f6fe5ceb03c1267801ff720edd2f8463e7effac6c6");
+    BOOST_CHECK(u2s(u_bigint) == u_bigint);
+    ///=========test s2u==================
+    s256 s_bigint("0x7170d8e0ae1b57d7ecc121f6fe5ceb03c1267801ff720edd2f8463e7effac6c6");
+    BOOST_CHECK(s2u(s_bigint) == s_bigint);
+    s_bigint = s256("0xf170d8e0ae1b57d7ecc121f6fe5ceb03c1267801ff720edd2f8463e7effac6c6");
+    BOOST_CHECK(s2u(s_bigint) == u256(c_end + s_bigint));
+    ///=========test exp10==================
+    BOOST_CHECK(exp10<1>() == u256(10));
+    BOOST_CHECK(exp10<9>() == u256(1000000000));
+    BOOST_CHECK(exp10<0>() == u256(1));
+    ///=========test diff==================
+    int a = 10;
+    int b = 20;
+    BOOST_CHECK(diff(a, b) == diff(b, a));
+    BOOST_CHECK(diff(b, a) == 10);
+    b = 10;
+    BOOST_CHECK(diff(a, b) == diff(b, a));
+    BOOST_CHECK(diff(b, a) == 0);
+    u256 a_u256("0xf170d8e0ae1b57d7ecc121f6fe5ceb03c1267801ff720edd2f8463e7effac6c6");
+    u256 b_u256("0xf170d8e0ae1b57d7ecc121f6fe5ceb03c1267801ff720edd2f8463e7effac6c4");
+    BOOST_CHECK(diff(a_u256, b_u256) == diff(b_u256, a_u256));
+    BOOST_CHECK(diff(a_u256, b_u256) == u256(2));
+}
+/// test utcTime
+BOOST_AUTO_TEST_CASE(testUtcTime)
+{
+    uint64_t old_time = utcTime();
+    usleep(1000);
+    BOOST_CHECK(old_time < utcTime());
+}
+/// test Timer
+BOOST_AUTO_TEST_CASE(testTimer)
+{
+    Timer timer;
+    usleep(10);
+    double elapsed = timer.elapsed();
+    BOOST_CHECK(elapsed >= 0.00001);
+    timer.restart();
+}
+
+class FakeCheckInvariants : public HasInvariants
+{
+public:
+    FakeCheckInvariants(bool _hasInvariants = true) : m_hasInvariants(_hasInvariants) {}
+    virtual bool invariants() const { return m_hasInvariants; }
+    void setHasInvariants(bool _hasInvariants) { m_hasInvariants = _hasInvariants; }
+    void check() { DEV_INVARIANT_CHECK_HERE; }
+
+private:
+    bool m_hasInvariants;
+};
+BOOST_AUTO_TEST_CASE(testCheckInvariants)
+{
+    FakeCheckInvariants fake_invariant;
+    BOOST_REQUIRE_NO_THROW(fake_invariant.check());
+    fake_invariant.setHasInvariants(false);
+    BOOST_CHECK_THROW(fake_invariant.check(), FailedInvariant);
+}
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace test
+}  // namespace dev

--- a/test/unittests/libevm/FakeExtVMFace.h
+++ b/test/unittests/libevm/FakeExtVMFace.h
@@ -1,3 +1,4 @@
+#include <evmc/helpers.h>
 #include <libdevcore/CommonJS.h>
 #include <libdevcore/SHA3.h>
 #include <libdevcrypto/Common.h>


### PR DESCRIPTION
1.add DEBUG to EthOptions.cmake && add ETH_DEBGU and ETH_TESTS definition when either DEBUG and TESTS flag is setted
2. remove useless functions: toLog2, inUnits && remove useless micro-definition 'DEV_IF_THROWS' && add ETH_TESTS flag to recover the DEV_INVARANIT_CHECK in both debug mode and test mode
3. add unit tests for Common.* of libdevcore