### PR TITLE
fix p2p bug caused by reconnect && modify the log-level of PBFT module && modify log format

### DIFF
--- a/libconsensus/ConsensusEngineBase.cpp
+++ b/libconsensus/ConsensusEngineBase.cpp
@@ -74,31 +74,31 @@ void ConsensusEngineBase::checkBlockValid(Block const& block)
     /// check the timestamp
     if (block.blockHeader().timestamp() > utcTime() && !m_allowFutureBlocks)
     {
-        ENGINE_LOG(WARNING) << "[#checkBlockValid] Future timestamp: [timestamp/utcTime/hash]:  "
-                            << block.blockHeader().timestamp() << "/" << utcTime() << "/"
-                            << block_hash << std::endl;
+        ENGINE_LOG(DEBUG) << "[#checkBlockValid] Future timestamp: [timestamp/utcTime/hash]:  "
+                          << block.blockHeader().timestamp() << "/" << utcTime() << "/"
+                          << block_hash << std::endl;
         BOOST_THROW_EXCEPTION(DisabledFutureTime() << errinfo_comment("Future time Disabled"));
     }
     /// check the block number
     if (block.blockHeader().number() <= m_blockChain->number())
     {
-        ENGINE_LOG(WARNING) << "[#checkBlockValid] Old height: [blockNumber/number/hash]:  "
-                            << block.blockHeader().number() << "/" << m_blockChain->number() << "/"
-                            << block_hash << std::endl;
+        ENGINE_LOG(DEBUG) << "[#checkBlockValid] Old height: [blockNumber/number/hash]:  "
+                          << block.blockHeader().number() << "/" << m_blockChain->number() << "/"
+                          << block_hash << std::endl;
         BOOST_THROW_EXCEPTION(InvalidBlockHeight() << errinfo_comment("Invalid block height"));
     }
     /// check existence of this block (Must non-exist)
     if (blockExists(block_hash))
     {
-        ENGINE_LOG(WARNING) << "[#checkBlockValid] Block already exist: [hash]:  " << block_hash
-                            << std::endl;
+        ENGINE_LOG(DEBUG) << "[#checkBlockValid] Block already exist: [hash]:  " << block_hash
+                          << std::endl;
         BOOST_THROW_EXCEPTION(ExistedBlock() << errinfo_comment("Block Already Existed, drop now"));
     }
     /// check the existence of the parent block (Must exist)
     if (!blockExists(block.blockHeader().parentHash()))
     {
-        ENGINE_LOG(WARNING) << "[#checkBlockValid] Parent doesn't exist: [hash]:  " << block_hash
-                            << std::endl;
+        ENGINE_LOG(DEBUG) << "[#checkBlockValid] Parent doesn't exist: [hash]:  " << block_hash
+                          << std::endl;
         BOOST_THROW_EXCEPTION(ParentNoneExist() << errinfo_comment("Parent Block Doesn't Exist"));
     }
     if (block.blockHeader().number() > 1)
@@ -106,11 +106,11 @@ void ConsensusEngineBase::checkBlockValid(Block const& block)
         if (m_blockChain->numberHash(block.blockHeader().number() - 1) !=
             block.blockHeader().parentHash())
         {
-            ENGINE_LOG(WARNING) << "[#checkBlockValid] Invalid block for unconsistent parentHash: "
-                                   "[block.parentHash/parentHash]:  "
-                                << toHex(block.blockHeader().parentHash()) << "/"
-                                << toHex(m_blockChain->numberHash(block.blockHeader().number() - 1))
-                                << std::endl;
+            ENGINE_LOG(DEBUG) << "[#checkBlockValid] Invalid block for unconsistent parentHash: "
+                                 "[block.parentHash/parentHash]:  "
+                              << toHex(block.blockHeader().parentHash()) << "/"
+                              << toHex(m_blockChain->numberHash(block.blockHeader().number() - 1))
+                              << std::endl;
         }
     }
 }

--- a/libconsensus/ConsensusEngineBase.h
+++ b/libconsensus/ConsensusEngineBase.h
@@ -203,7 +203,7 @@ protected:
         }
         catch (std::exception& e)
         {
-            ENGINE_LOG(WARNING) << "[#decodeToRequests] Invalid network-received packet";
+            ENGINE_LOG(DEBUG) << "[#decodeToRequests] Invalid network-received packet";
             return false;
         }
     }

--- a/libconsensus/pbft/PBFTEngine.h
+++ b/libconsensus/pbft/PBFTEngine.h
@@ -261,8 +261,8 @@ protected:
         peerIndex = getIndexByMiner(session->nodeID());
         if (peerIndex < 0)
         {
-            PBFTENGINE_LOG(WARNING)
-                << "[#isValidReq] Recv PBFT msg from unkown peer:  " << session->nodeID();
+            PBFTENGINE_LOG(DEBUG) << "[#isValidReq] Recv PBFT msg from unkown peer:  "
+                                  << session->nodeID();
             return false;
         }
         /// check whether this node is in the miner list
@@ -296,7 +296,7 @@ protected:
     {
         if (m_reqCache->prepareCache().block_hash != req.block_hash)
         {
-            PBFTENGINE_LOG(WARNING)
+            PBFTENGINE_LOG(DEBUG)
                 << "#[checkReq] sign or commit Not exist in prepare cache: [prepHash/hash]:"
                 << m_reqCache->prepareCache().block_hash.abridged() << "/" << req.block_hash
                 << "  [INFO]:  " << oss.str();
@@ -314,22 +314,21 @@ protected:
         /// check the sealer of this request
         if (req.idx == m_idx)
         {
-            PBFTENGINE_LOG(WARNING) << "[#checkReq] Recv own req  [INFO]:  " << oss.str();
+            PBFTENGINE_LOG(DEBUG) << "[#checkReq] Recv own req  [INFO]:  " << oss.str();
             return CheckResult::INVALID;
         }
         /// check view
         if (m_reqCache->prepareCache().view != req.view)
         {
-            PBFTENGINE_LOG(WARNING)
+            PBFTENGINE_LOG(DEBUG)
                 << "[#checkReq] Recv req with unconsistent view: [prepView/view]:  "
                 << m_reqCache->prepareCache().view << "/" << req.view << "  [INFO]: " << oss.str();
             return CheckResult::INVALID;
         }
         if (!checkSign(req))
         {
-            PBFTENGINE_LOG(WARNING)
-                << "[#checkReq] invalid sign: [hash]:" << req.block_hash.abridged()
-                << "  [INFO]: " << oss.str();
+            PBFTENGINE_LOG(DEBUG) << "[#checkReq] invalid sign: [hash]:"
+                                  << req.block_hash.abridged() << "  [INFO]: " << oss.str();
             return CheckResult::INVALID;
         }
         return CheckResult::VALID;
@@ -389,12 +388,13 @@ protected:
         /// get leader failed or this prepareReq is not broadcasted from leader
         if (!leader.first || req.idx != leader.second)
         {
-            PBFTENGINE_LOG(WARNING)
-                << "[#InvalidPrepare] Get leader failed: "
-                   "[cfgErr/idx/req.idx/leader/m_leaderFailed/view/highSealer/highNumber]:  "
-                << m_cfgErr << "/" << nodeIdx() << "/" << req.idx << "/" << leader.second << "/"
-                << m_leaderFailed << "/" << m_highestBlock.sealer() << "/"
-                << m_highestBlock.number();
+            if (!m_emptyBlockViewChange)
+                PBFTENGINE_LOG(WARNING)
+                    << "[#InvalidPrepare] Get leader failed: "
+                       "[cfgErr/idx/req.idx/leader/m_leaderFailed/view/highSealer/highNumber]:  "
+                    << m_cfgErr << "/" << nodeIdx() << "/" << req.idx << "/" << leader.second << "/"
+                    << m_leaderFailed << "/" << m_highestBlock.sealer() << "/"
+                    << m_highestBlock.number();
             return false;
         }
 
@@ -453,6 +453,7 @@ protected:
 
     /// the block number that update the miner list
     int64_t m_lastObtainMinerNum = 0;
+    bool m_emptyBlockViewChange = false;
 };
 }  // namespace consensus
 }  // namespace dev

--- a/libconsensus/pbft/PBFTMsgCache.h
+++ b/libconsensus/pbft/PBFTMsgCache.h
@@ -64,7 +64,7 @@ public:
             insertMessage(x_knownViewChange, m_knownViewChange, c_knownViewChange, key);
             return true;
         default:
-            LOG(WARNING) << "Invalid packet type:" << type;
+            LOG(DEBUG) << "Invalid packet type:" << type;
             return false;
         }
     }
@@ -90,7 +90,7 @@ public:
         case ViewChangeReqPacket:
             return exists(x_knownViewChange, m_knownViewChange, key);
         default:
-            LOG(WARNING) << "Invalid packet type:" << type;
+            LOG(DEBUG) << "Invalid packet type:" << type;
             return false;
         }
     }

--- a/libinitializer/LedgerInitializer.cpp
+++ b/libinitializer/LedgerInitializer.cpp
@@ -89,9 +89,7 @@ bool LedgerInitializer::initSingleGroup(
     _groudID2NodeList[_groupID] =
         m_ledgerManager->getParamByGroupId(_groupID)->mutableConsensusParam().minerList;
 
-    INITIALIZER_LOG(DEBUG) << "[#initSingleGroup] [groupID/count/status]: "
-                           << std::to_string(_groupID) << "/" << _groudID2NodeList[_groupID].size()
-                           << "/" << m_ledgerManager->consensus(_groupID)->consensusStatus();
+    INITIALIZER_LOG(DEBUG) << "[#initSingleGroup] [groupID/]: " << std::to_string(_groupID);
     for (auto i : _groudID2NodeList[_groupID])
         INITIALIZER_LOG(TRACE) << "miner:" << toHex(i);
     return succ;

--- a/libnetwork/Common.h
+++ b/libnetwork/Common.h
@@ -216,7 +216,7 @@ struct NodeIPEndpoint
     bool operator!=(NodeIPEndpoint const& _cmp) const { return !operator==(_cmp); }
     bool operator<(const dev::p2p::NodeIPEndpoint& rhs) const
     {
-        if (address < rhs.address && tcpPort < rhs.tcpPort)
+        if (address < rhs.address || tcpPort < rhs.tcpPort)
         {
             return true;
         }
@@ -228,7 +228,7 @@ struct NodeIPEndpoint
     }
     bool operator>(const dev::p2p::NodeIPEndpoint& rhs) const
     {
-        if (address > rhs.address && tcpPort > rhs.tcpPort)
+        if (address > rhs.address || tcpPort > rhs.tcpPort)
             return true;
         if (udpPort > rhs.udpPort)
             return true;

--- a/libnetwork/Host.cpp
+++ b/libnetwork/Host.cpp
@@ -107,10 +107,6 @@ void Host::startAccept(boost::system::error_code boost_error)
                     NodeIPEndpoint(endpoint.address(), endpoint.port(), endpoint.port()));
                 HOST_LOG(DEBUG) << "client port:" << endpoint.port()
                                 << "|ip:" << endpoint.address().to_string();
-#if 0
-                HOST_LOG(DEBUG) << "server port:" << m_listenPort
-                           << "|ip:" << m_listenHost;
-#endif
                 /// register ssl callback to get the NodeID of peers
                 std::shared_ptr<std::string> endpointPublicKey = std::make_shared<std::string>();
                 m_asioInterface->setVerifyCallback(socket, newVerifyCallback(endpointPublicKey));
@@ -219,7 +215,9 @@ void Host::handshakeServer(const boost::system::error_code& error,
 {
     if (error)
     {
-        HOST_LOG(WARNING) << "Handshake failed: " << error << socket->nodeIPEndpoint().name();
+        HOST_LOG(WARNING) << "[#handshakeServer] Handshake failed: [eid/emsg/endpoint]: "
+                          << error.value() << "/" << error.message() << "/"
+                          << socket->nodeIPEndpoint().name();
         socket->close();
 
         return;
@@ -229,16 +227,7 @@ void Host::handshakeServer(const boost::system::error_code& error,
     {
         std::string node_id_str(*endpointPublicKey);
         NodeID nodeID = NodeID(node_id_str);
-        /// handshake failed
-        if (error)
-        {
-            HOST_LOG(ERROR) << "Host::async_handshake err:" << error.message();
-            socket->close();
-            return;
-        }
-
         startPeerSession(nodeID, socket, m_connectionHandler);
-
         startAccept();
     }
 }
@@ -273,8 +262,9 @@ void Host::startPeerSession(NodeID nodeID, std::shared_ptr<SocketFace> const& so
             HOST_LOG(WARNING) << "No connectionHandler, new connection may lost";
         }
     });
-
-    HOST_LOG(INFO) << "start a new peer: " << nodeID;
+    HOST_LOG(INFO) << "[#startPeerSession] [remoteEndpoint/nodeID]: "
+                   << socket->remote_endpoint().address().to_string() << ":"
+                   << socket->remote_endpoint().port() << "/" << nodeID;
 }
 
 /**
@@ -397,7 +387,9 @@ void Host::handshakeClient(const boost::system::error_code& error,
 
     if (error)
     {
-        HOST_LOG(WARNING) << "Handshake failed: " << error << " " << _nodeIPEndpoint.name();
+        HOST_LOG(WARNING) << "[#handshakeClient] Handshake failed: [eid/emsg/endpoint]: "
+                          << error.value() << "/" << error.message() << "/"
+                          << _nodeIPEndpoint.name();
         socket->close();
 
         return;
@@ -407,14 +399,6 @@ void Host::handshakeClient(const boost::system::error_code& error,
     {
         std::string node_id_str(*endpointPublicKey);
         NodeID nodeID = NodeID(node_id_str);
-        /// handshake failed
-        if (error)
-        {
-            HOST_LOG(ERROR) << "Host::async_handshake client err:" << error.message();
-            socket->close();
-            return;
-        }
-
         startPeerSession(nodeID, socket, callback);
     }
 }

--- a/tools/RpcTool.sh
+++ b/tools/RpcTool.sh
@@ -30,14 +30,14 @@ ip="127.0.0.1"
 rpc_port=
 rpc_command=
 function_name=
-support_rpc="getBlockNumber getPbftView getConsensusStatus getSyncStatus getClientVersion getPeers getGroupPeers getGroupList getPendingTransactions getTotalTransactionCount"
+support_rpc="getBlockNumber getPbftView getConsensusStatus getSyncStatus getClientVersion getPeers getGroupPeers getGroupList getPendingTransactions getTotalTransactionCount getMinerList"
 execRpcCommand() 
 {
     local functionName="${1}"
     if [ "${all_groups}" == true ];then
-        rpc_command="curl -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"${functionName}\",\"params\":[],\"id\":83}' http://${ip}:${rpc_port} | jq"
+        rpc_command="curl -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"${functionName}\",\"params\":[],\"id\":83}' http://${ip}:${rpc_port} "
     else
-        rpc_command="curl -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"${functionName}\",\"params\":[${group_id}],\"id\":83}' http://${ip}:${rpc_port} | jq"
+        rpc_command="curl -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"${functionName}\",\"params\":[${group_id}],\"id\":83}' http://${ip}:${rpc_port}"
     fi
     execute_cmd "${rpc_command}"
 }
@@ -68,11 +68,11 @@ checkParam()
         help
     fi
     
-    result=`echo ${support_rpc} | grep -w ${function_name}`
-    if [ "${result}" == "" ];then
-        LOG_ERROR "Not support "${function_name}" yet!"
-        help
-    fi
+    #result=`echo ${support_rpc} | grep -w ${function_name}`
+    #if [ "${result}" == "" ];then
+    #    LOG_ERROR "Not support "${function_name}" yet!"
+    #    help
+    #fi
 }
 
 help()

--- a/tools/RpcTool.sh
+++ b/tools/RpcTool.sh
@@ -35,9 +35,9 @@ execRpcCommand()
 {
     local functionName="${1}"
     if [ "${all_groups}" == true ];then
-        rpc_command="curl -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"${functionName}\",\"params\":[],\"id\":83}' http://${ip}:${rpc_port} "
+        rpc_command="curl -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"${functionName}\",\"params\":[],\"id\":83}' http://${ip}:${rpc_port} | jq"
     else
-        rpc_command="curl -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"${functionName}\",\"params\":[${group_id}],\"id\":83}' http://${ip}:${rpc_port}"
+        rpc_command="curl -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"${functionName}\",\"params\":[${group_id}],\"id\":83}' http://${ip}:${rpc_port} | jq"
     fi
     execute_cmd "${rpc_command}"
 }


### PR DESCRIPTION
1. fix p2p bug caused by reconnect (operator < overload of NodeEndPoint is wrong)
2. modify the log-level of PBFT module (from WARNING to DEBUG)
3. add non-omit-empty-block viewchange warning log
4. modify log format for p2p