### PR TITLE
Disable re-send known txs

### DIFF
--- a/libsync/SyncMaster.cpp
+++ b/libsync/SyncMaster.cpp
@@ -199,7 +199,9 @@ void SyncMaster::maintainTransactions()
     {
         auto const& t = ts[i];
         NodeIDs peers;
-        unsigned _percent = m_txPool->isTransactionKnownBySomeone(t.sha3()) ? 25 : 100;
+
+        // Send received txs to 0% peers and send new txs to 100% peers
+        unsigned _percent = m_txPool->isTransactionKnownBySomeone(t.sha3()) ? 0 : 100;
 
         peers = m_syncStatus->randomSelection(_percent, [&](std::shared_ptr<SyncPeerStatus> _p) {
             bool unsent = !m_txPool->isTransactionKnownBy(t.sha3(), m_nodeId);


### PR DESCRIPTION
Disable sending received transactions to peers.
Disable sending to witness node will be coded later.